### PR TITLE
solution: add initial material-ui theme

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,1 +1,2 @@
 import '@storybook/addon-actions/register';
+import 'storybook-addon-material-ui';

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "flow-bin": "^0.61.0",
     "flow-copy-source": "^1.2.1",
     "jest": "^21.2.1",
-    "raf": "^3.4.0"
+    "raf": "^3.4.0",
+    "storybook-addon-material-ui": "0.8.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/src/theme.json
+++ b/src/theme.json
@@ -1,0 +1,35 @@
+{
+    "spacing": {
+        "iconSize": 24,
+        "desktopGutter": 24,
+        "desktopGutterMore": 32,
+        "desktopGutterLess": 16,
+        "desktopGutterMini": 8,
+        "desktopKeylineIncrement": 64,
+        "desktopDropDownMenuItemHeight": 32,
+        "desktopDropDownMenuFontSize": 15,
+        "desktopDrawerMenuItemHeight": 48,
+        "desktopSubheaderHeight": 48,
+        "desktopToolbarHeight": 56
+    },
+    "fontFamily": "Roboto, sans-serif",
+    "borderRadius": 2,
+    "palette": {
+        "primary1Color": "#00bcd4",
+        "primary2Color": "#0097a7",
+        "primary3Color": "#bdbdbd",
+        "accent1Color": "#ff4081",
+        "accent2Color": "#f5f5f5",
+        "accent3Color": "#9e9e9e",
+        "textColor": "rgba(0, 0, 0, 0.87)",
+        "secondaryTextColor": "rgba(0, 0, 0, 0.54)",
+        "alternateTextColor": "#ffffff",
+        "canvasColor": "#ffffff",
+        "borderColor": "#e0e0e0",
+        "disabledColor": "rgba(0, 0, 0, 0.3)",
+        "pickerHeaderColor": "#00bcd4",
+        "clockCircleColor": "rgba(0, 0, 0, 0.07)",
+        "shadowColor": "rgba(0, 0, 0, 1)"
+    },
+    "themeName": "Emerald Theme"
+}

--- a/stories/Account/index.js
+++ b/stories/Account/index.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import Account from '../../src/components/Account';
+import { muiTheme } from 'storybook-addon-material-ui';
+import theme from '../../src/theme.json';
 
 storiesOf('Account', module)
-  .addDecorator(story => (
-    <MuiThemeProvider>
-      {story()}
-    </MuiThemeProvider>
-  ))
+  .addDecorator(muiTheme([theme]))
   .add('default', () => (
     <Account
       addr="0xFBb1b73C4f0BDa4f67dcA266ce6Ef42f520fBB98"

--- a/stories/Address/index.js
+++ b/stories/Address/index.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import Address from '../../src/components/Address';
+import { muiTheme } from 'storybook-addon-material-ui';
+import theme from '../../src/theme.json';
 
 storiesOf('Address', module)
-  .addDecorator(story => (
-    <MuiThemeProvider>
-      {story()}
-    </MuiThemeProvider>
-  ))
+  .addDecorator(muiTheme([theme]))
   .add('default', () => (<Address id="0xFBb1b73C4f0BDa4f67dcA266ce6Ef42f520fBB98" />))
   .add('without id', () => (<Address />))
   .add('shortened', () => (<Address shortened id="0xFBb1b73C4f0BDa4f67dcA266ce6Ef42f520fBB98" />))


### PR DESCRIPTION
we need to get the colors correct but this adds the default theme for now.

![image](https://user-images.githubusercontent.com/364566/34590906-8b2b87be-f16e-11e7-9d74-aea1461ca12d.png)

fixes #7 
  
more on `material-ui` addon for storybook:
https://github.com/react-theming/storybook-addon-material-ui#usage-details